### PR TITLE
fix(Tools): Use POST requests for data slicer form.

### DIFF
--- a/modules/EnsEMBL/Web/Command/Wizard.pm
+++ b/modules/EnsEMBL/Web/Command/Wizard.pm
@@ -1,0 +1,78 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+package EnsEMBL::Web::Command::Wizard;
+
+## Generic module for redirecting wizard nodes 
+## depending on which form button is clicked
+
+use strict;
+use warnings;
+
+use base qw(EnsEMBL::Web::Command);
+
+sub process {
+  my $self   = shift;
+  my $hub    = $self->hub;
+  my $back   = $hub->param('wizard_back'); # Check if we're going back
+  my @steps  = $hub->param('_backtrack');
+  my $params = {};
+  my $url;
+  
+  if ($back) {
+    my $current_node = 'Summary'; ## Default value to stop Magic from barfing
+    my $species = $hub->type eq 'UserData' ? $hub->data_species : $hub->species;
+    
+    $url .= $hub->species_path($species) if $species;
+    $url .= '/' . $hub->type;
+    
+    pop @steps;
+    $current_node = pop @steps;
+    $url .= "/$current_node";
+  } else {
+    $url = $hub->param('wizard_next');
+  }
+  
+  # Pass the "normal" parameters but munge the wizard ones
+  foreach my $name ($hub->param) {
+    next if $name =~ /^wizard_/;
+    
+    my @value = $hub->param($name);
+    my $value = (@value) ? \@value : $value[0];
+    
+    if ($name eq '_backtrack' && $back) {
+      $value = \@steps;
+      
+      if (scalar @steps) {
+        $hub->param('_backtrack', @steps);
+      } else {
+        $hub->delete_param('_backtrack');
+      }
+    };
+    
+    $params->{$name} = $value;
+  }
+
+  # I know we should be calling $self->ajax_redirect($url, $params) here.
+  # But this will redirect POST request to another POST request with different URI.
+  my $r = $self->page->renderer->{'r'};
+  $r->headers_out->set('Location' => $url);
+  $r->status(Apache2::Const::HTTP_TEMPORARY_REDIRECT);
+}
+
+1;

--- a/modules/EnsEMBL/Web/Component/UserData/SelectSlice.pm
+++ b/modules/EnsEMBL/Web/Component/UserData/SelectSlice.pm
@@ -178,7 +178,7 @@ sub content {
   }
 
   #FILTER FORM 
-  my $form = $self->modal_form('selectfilter', "$current_species/UserData/SliceFile", { 'wizard' => 1, 'back_button' => 1, 'method' => 'get'});
+  my $form = $self->modal_form('selectfilter', "$current_species/UserData/SliceFile", { 'wizard' => 1, 'back_button' => 1, 'method' => 'post'});
   $form->add_element(type =>  'Hidden', name => 'region',    'value' => $region);
   $form->add_element(type =>  'Hidden', name => 'url',       'value' => $url);
   $form->add_element(type =>  'Hidden', name => 'vcffilter', 'value' => '1');


### PR DESCRIPTION
This change use POST requests for sending form data in the body so that it can avoid the URL length limit for GET reqeusts.

Fixes ENSEMBL-4455.
