### PR TITLE
fix(VCF URL): fix the default VCF file URLs for chr MT in Variation P…

### DIFF
--- a/modules/EnsEMBL/Web/Component/UserData/Haploview.pm
+++ b/modules/EnsEMBL/Web/Component/UserData/Haploview.pm
@@ -41,7 +41,9 @@ sub content {
   if (!$check_data && !$process) {
 
     my ($chr) = $r ? split /:/, $r : split /:/, $regioneg;
-    $vcfurl   = $species_defs->LATEST_RELEASE_VCF ? sprintf ($species_defs->LATEST_RELEASE_VCF, $chr) : '';
+    my $chr_u = "LATEST_RELEASE_VCF_$chr";
+    $vcfurl   = $species_defs->$chr_u;  
+    $vcfurl ||= $species_defs->LATEST_RELEASE_VCF ? sprintf ($species_defs->LATEST_RELEASE_VCF, $chr) : '';
 
       my $html= qq(<div id="VCFtoPEDconverter" class="js_panel __h __h_comp_VCFtoPEDconverter" style="overflow-x: auto;">
        <form name="haploview" class="check std" method="get" action="$current_species/UserData/Haploview">

--- a/modules/EnsEMBL/Web/Component/UserData/VariationsMapVCF.pm
+++ b/modules/EnsEMBL/Web/Component/UserData/VariationsMapVCF.pm
@@ -30,7 +30,9 @@ sub content {
     my $regioneg  = '6:46620015-46620998';
     my ($chr)     = $r ? split /:/, $r : split /:/, $regioneg;
     my ($chreg)   = split /:/, $regioneg;
-    my $url_value = $hub->species_defs->LATEST_RELEASE_VCF ? sprintf ($hub->species_defs->LATEST_RELEASE_VCF, $chr)    : '';
+    my $chr_url   = "LATEST_RELEASE_VCF_$chr";
+    my $url_value = $hub->species_defs->$chr_url;
+    $url_value  ||= $hub->species_defs->LATEST_RELEASE_VCF ? sprintf ($hub->species_defs->LATEST_RELEASE_VCF, $chr)    : '';
     my $url_note  = $hub->species_defs->LATEST_RELEASE_VCF ? sprintf ($hub->species_defs->LATEST_RELEASE_VCF, $chreg)  : ''; 	     
 
     unless ($variation_mapper) {


### PR DESCRIPTION
…attern Finder and VCF to PED converter

Data for different chromsomes can come at a later date and does not follow LATEST_RELEASE_VCF template. In this case we set LATEST_RELEASE_VCF_$CHR to point to the specific file.

This change make sure we check for specific file for the chromosome first. If it is not set, then we follow the LATEST_RELEASE_VCF template.

Related to ENSEMBL-4516.
