### PR TITLE
Update ftp links to https

### DIFF
--- a/conf/ini-files/Homo_sapiens.ini
+++ b/conf/ini-files/Homo_sapiens.ini
@@ -8,12 +8,12 @@
 [general]
 SPECIES_RELEASE_VERSION = 37
 ALTERNATIVE_ASSEMBLIES    = [ ]
-LATEST_RELEASE_VCF        = ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr%s.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz
+LATEST_RELEASE_VCF        = https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chr%s.phase3_shapeit2_mvncall_integrated_v5a.20130502.genotypes.vcf.gz
 LATEST_RELEASE_VCF_MT_Y   = 
-LATEST_RELEASE_VCF_MT   = ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz
-LATEST_RELEASE_VCF_Y   = ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrY.phase3_integrated_v1b.20130502.genotypes.vcf.gz
-LATEST_RELEASE_VCF_X   = ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz
-LATEST_RELEASE_SAMPLE     = ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/integrated_call_samples_v3.20130502.ALL.panel
+LATEST_RELEASE_VCF_MT   = https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrMT.phase3_callmom-v0_4.20130502.genotypes.vcf.gz
+LATEST_RELEASE_VCF_Y   = https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrY.phase3_integrated_v1b.20130502.genotypes.vcf.gz
+LATEST_RELEASE_VCF_X   = https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrX.phase3_shapeit2_mvncall_integrated_v1b.20130502.genotypes.vcf.gz
+LATEST_RELEASE_SAMPLE     = https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/integrated_call_samples_v3.20130502.ALL.panel
 #comma-separated list of vcf tracks switched on by default: 
 #DEFAULT_VCF_TRACKS        = ALL - phase 1 integrated release - 1000 Genomes
 DEFAULT_VCF_TRACKS        = kg_feature_variation___All
@@ -99,7 +99,7 @@ key = vcf_1kg_vqsr
 source_url =  /nfs/public/rw/ensembl/1000genomes/data/vcf/ALL.wgs.phase1.projectConsensus.snps.sites.vcf.gz
 #source_url = /nfs/nobackup/ensembl/ek/1000genomes/vcf/ALL.wgs.phase1.projectConsensus.snps.sites.vcf.gz
 source_name = Interim Phase 1 VQSR sites
-description = Interim Phase 1 VQSR sites from ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20110511_interim_release/ALL.wgs.phase1.projectConsensus.snps.sites.vcf.gz
+description = Interim Phase 1 VQSR sites from https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20110511_interim_release/ALL.wgs.phase1.projectConsensus.snps.sites.vcf.gz
 
 
 [SAMPLE_DATA]

--- a/htdocs/forge/Pulmonary_function.vcf.txt
+++ b/htdocs/forge/Pulmonary_function.vcf.txt
@@ -17,7 +17,7 @@
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=DS,Number=1,Type=Float,Description="Genotype dosage from MaCH/Thunder">
 ##FORMAT=<ID=GL,Number=.,Type=Float,Description="Genotype Likelihoods">
-##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele, ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele, https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README">
 ##INFO=<ID=AF,Number=1,Type=Float,Description="Global Allele Frequency based on AC/AN">
 ##INFO=<ID=AMR_AF,Number=1,Type=Float,Description="Allele Frequency for samples from AMR based on AC/AN">
 ##INFO=<ID=ASN_AF,Number=1,Type=Float,Description="Allele Frequency for samples from ASN based on AC/AN">

--- a/htdocs/ssi/1000genome_links.inc
+++ b/htdocs/ssi/1000genome_links.inc
@@ -17,9 +17,9 @@ This browser is based on Ensembl release 73 and represents the variant set analy
 </td>
 </tr>
 
-<td><a href="ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/1000genomes_browser_main_project_20101123/20111013_ensembl_browser_63.doc" target="_blank"><img src="/i/species/48/Homo_sapiens.png" alt="" style="border:1px solid #99c;" /></a></td>
+<td><a href="https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/1000genomes_browser_main_project_20101123/20111013_ensembl_browser_63.doc" target="_blank"><img src="/i/species/48/Homo_sapiens.png" alt="" style="border:1px solid #99c;" /></a></td>
 <td width="90%">
-  <a href="ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/1000genomes_browser_main_project_20110521/The_1000_Genomes_Browser_Tutorial.ensembl_65.doc" target="_blank"><b>Tutorial</b></a> &rarr;<br />
+  <a href="https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/1000genomes_browser_main_project_20110521/The_1000_Genomes_Browser_Tutorial.ensembl_65.doc" target="_blank"><b>Tutorial</b></a> &rarr;<br />
   The 1000 Genomes Browser Tutorial.
 </td>
 </tr>

--- a/htdocs/ssi/newrelease.inc
+++ b/htdocs/ssi/newrelease.inc
@@ -1,6 +1,6 @@
 <div class="white boxed">
 <h1 class="first section_title">Browser update October 2014</h1>
-<h2>This release is based on <a href="http://grch37.ensembl.org">Ensembl 80</a> and contains the phase 3 integrated release for 2504 individuals. The data can be found on <a href="ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/" target="_blank">the ftp site</a>.</h2>
+<h2>This release is based on <a href="http://grch37.ensembl.org">Ensembl 80</a> and contains the phase 3 integrated release for 2504 individuals. The data can be found on <a href="https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/" target="_blank">the ftp site</a>.</h2>
 <h2>Please see <a href="http://www.1000genomes.org">www.1000genomes.org</a> for more information about the data presented here and instructions for downloading the complete data set.</h2>
 <ul>
 <li> <a href="/Homo_sapiens/Location/View?r=6:133098746-133108745">View sample data</a> </li>

--- a/htdocs/ssi/species/Homo_sapiens_variation.html
+++ b/htdocs/ssi/species/Homo_sapiens_variation.html
@@ -1,6 +1,6 @@
 <h3 style="clear:both">Variation</h3>
 <p class="space-below"> 
-In order to facilitate immediate analysis of the 1000 Genomes Project data by the whole scientific community, this browser (based on Ensembl) integrates the SNP and INDEL calls from the <a href="ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20110521/">phase 1 integrated release</a>. 
+In order to facilitate immediate analysis of the 1000 Genomes Project data by the whole scientific community, this browser (based on Ensembl) integrates the SNP and INDEL calls from the <a href="https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20110521/">phase 1 integrated release</a>. 
 </p>
 <p class="space-below">
 This data has be submitted to dbSNP, and once rsid's have been allocated, will be absorbed into the UCSC and Ensembl browsers according to their respective release cycles. Until that point <b>any non rs SNP id's on this site are temporary and will NOT be maintained</b>. 

--- a/htdocs/tools.html
+++ b/htdocs/tools.html
@@ -25,21 +25,21 @@
   <a href="/info/website/upload/psl.html">PSL</a>
   <br />N.B. Export is currently in GFF only</td>
   <td><a href="/[[SPECIESDEFS::ENSEMBL_PRIMARY_SPECIES]]/UserData/SelectFeatures" class="modal_link-no">Online version</a></td>
-  <td><a href="ftp://ftp.ensembl.org/pub/misc-scripts/Assembly_mapper_1.0/">API script</a></td>
+  <td><a href="https://ftp.ensembl.org/pub/misc-scripts/Assembly_mapper_1.0/">API script</a></td>
 </tr>
 
 <tr class="bg2">
   <td>ID History converter</td>
   <td>Convert a set of Ensembl IDs from a previous release into their current equivalents.</td>
   <td><a href="/[[SPECIESDEFS::ENSEMBL_PRIMARY_SPECIES]]/UserData/UploadStableIDs" class="modal_link-no">Online version</a><br />(max 30 ids)</td>
-  <td><a href="ftp://ftp.ensembl.org/pub/misc-scripts/ID_mapper_1.0/">API script</a></td>
+  <td><a href="https://ftp.ensembl.org/pub/misc-scripts/ID_mapper_1.0/">API script</a></td>
 </tr>
 
 <tr>
   <td>Variant Effect Predictor</td>
   <td>(Formerly SNP Effect Predictor). Upload a set of SNPs in our <a href="/info/website/upload/var.html">standard format</a> and export a file containing consequence types. Uploaded tracks can also be viewed on Location pages.</td>
   <td><a href="/[[SPECIESDEFS::ENSEMBL_PRIMARY_SPECIES]]/UserData/UploadVariations" class="modal_link-no">Online version</a><br />(max 750 SNPs)</td>
-  <td><a href="ftp://ftp.ensembl.org/pub/misc-scripts/Variant_effect_predictor/">API script</a></td>
+  <td><a href="https://ftp.ensembl.org/pub/misc-scripts/Variant_effect_predictor/">API script</a></td>
 </tr>
 <tr class="bg2">
   <td>Data Slicer</td>
@@ -51,14 +51,14 @@
   <td>Variation Pattern Finder</td>
   <td>Identify variation patterns in a chromosomal region of interest for different individuals. Only variations with functional significance such non-synonymous coding, splice site will be reported by the tool. Click <a href="http://www.1000genomes.org/variation-pattern-finder" target=_blank>here</a> for more extensive documentation. </td>
   <td><a href="/[[SPECIESDEFS::ENSEMBL_PRIMARY_SPECIES]]/UserData/VariationsMapVCF" class="modal_link-no">Online version</a><br /></td>
-  <td><a href="ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/variation_pattern_finder/version_1.0">API script</a></td>
+  <td><a href="https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/variation_pattern_finder/version_1.0">API script</a></td>
 </tr>
 
 <tr class="bg2">
   <td>VCF to PED converter</td>
   <td>The VCF to PED converter allows users to parse a vcf file to create a linkage pedigree file (ped) and a marker information file, which together may be loaded into ld visualization tools like Haploview. Click <a href="http://www.1000genomes.org/vcf-ped-converter" target=_blank>here</a> for more extensive documentation.</td>
   <td><a href="/[[SPECIESDEFS::ENSEMBL_PRIMARY_SPECIES]]/UserData/Haploview" class="modal_link-no">Online version</a><br /></td>
-  <td><a href="ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/vcf_to_ped_converter/version_1.1/">API script</a></td>
+  <td><a href="https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/vcf_to_ped_converter/version_1.1/">API script</a></td>
 </tr>
 
 <tr class="bg2">
@@ -72,7 +72,7 @@
   <td>Allele frequency calculator</td>
   <td>This tool takes a VCF file, a matching sample panel file, a chromosomal region, a population name and calculates population-wide allele frequency for sites within the chromosomal region defined.
   <td><a href="/[[SPECIESDEFS::ENSEMBL_PRIMARY_SPECIES]]/UserData/Allele" class="modal_link-no">Online version</a><br /></td>
-  <td><a href="ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/allele_frequency_calculator/">API script</a></td>
+  <td><a href="https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/browser/allele_frequency_calculator/">API script</a></td>
 </tr>
 </table>
 

--- a/modules/EnsEMBL/Web/Component/Info/HomePage.pm
+++ b/modules/EnsEMBL/Web/Component/Info/HomePage.pm
@@ -197,7 +197,7 @@ sub _variation_text {
 # 1KG
 #    if ($species_defs->ENSEMBL_FTP_URL) {
 #      my $ftp_url = sprintf '%s/release-%s/variation/gvf/%s/', $species_defs->ENSEMBL_FTP_URL, $ensembl_version, lc $species;
-    my $ftp_url = 'ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/';
+    my $ftp_url = 'https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/';
       $html   .= qq(
 <p><a href="$ftp_url" class="nodeco"><img src="${img_url}24/download.png" alt="" class="homepage-link" />Explore 1000 genomes raw data files</a> (VCF)</p>);
 #    }


### PR DESCRIPTION
This PR updates all ftp URLs to use https (to be compatible with web browsers).
The affected hostnames have been tested working with https.
Similar PRs in other repos are listed in the JIRA ticket.

JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632